### PR TITLE
Fix deprecated hook

### DIFF
--- a/dovecot_impersonate.php
+++ b/dovecot_impersonate.php
@@ -12,7 +12,7 @@ class dovecot_impersonate extends rcube_plugin {
   
   public function init() 
   {    
-    $this->add_hook('imap_connect', array($this, 'impersonate'));
+    $this->add_hook('storage_connect', array($this, 'impersonate'));
     $this->add_hook('managesieve_connect', array($this, 'impersonate'));
     $this->add_hook('authenticate', array($this, 'login'));  
   }


### PR DESCRIPTION
imap_connect is deprecated and replaced with storage_connect.

This was causing warnings on 0.9.0
